### PR TITLE
Add package.xml and validation workflow

### DIFF
--- a/.github/workflows/package_xml.yml
+++ b/.github/workflows/package_xml.yml
@@ -1,0 +1,11 @@
+name: Validate package.xml
+
+on:
+  pull_request:
+
+jobs:
+  package-xml:
+    runs-on: ubuntu-latest
+    name: Validate package.xml
+    steps:
+      - uses: gazebo-tooling/action-gz-ci/validate_package_xml@noble

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>gz-jetty</name>
+  <version>1.0.0</version>
+  <description>Gazebo Jetty Metapackage</description>
+  <maintainer email="addisu@openrobotics.org">Addisu Z. Taddese</maintainer>
+  <license>Apache License 2.0</license>
+  <url type="website">https://github.com/gazebosim/gz-jetty</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>gz-cmake4</depend>
+  <depend>gz-common6</depend>
+  <depend>gz-fuel_tools10</depend>
+  <depend>gz-gui10</depend>
+  <depend>gz-launch9</depend>
+  <depend>gz-math8</depend>
+  <depend>gz-msgs11</depend>
+  <depend>gz-physics8</depend>
+  <depend>gz-plugin3</depend>
+  <depend>gz-rendering9</depend>
+  <depend>gz-sensors9</depend>
+  <depend>gz-sim10</depend>
+  <depend>gz-transport14</depend>
+  <depend>gz-utils3</depend>
+  <depend>sdformat15</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
# 🎉 New feature

Adds a package.xml file

## Summary

I noticed that our Gazebo metapackages don't have package.xml files, but they easily could, so I added one for gz-jetty with @azeey as the maintainer.

## Test it

* Confirm that added workflow passes
* Add gz-jetty to a colcon workspace with other jetty packages and confirm that `colcon graph` properly recognizes package order

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
