### PR TITLE
Find gz-sim without major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ gz_configure_project(VERSION_SUFFIX)
 
 gz_find_package(gz-common6 REQUIRED)
 gz_find_package(gz-fuel_tools10 REQUIRED)
-gz_find_package(gz-sim10 REQUIRED)
+gz_find_package(gz-sim REQUIRED)
 gz_find_package(gz-gui10 REQUIRED)
 gz_find_package(gz-launch REQUIRED)
 gz_find_package(gz-math8 REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend>gz-plugin3</depend>
   <depend>gz-rendering9</depend>
   <depend>gz-sensors9</depend>
-  <depend>gz-sim10</depend>
+  <depend>gz-sim</depend>
   <depend>gz-transport14</depend>
   <depend>gz-utils3</depend>
   <depend>sdformat15</depend>


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1244, companion to gazebosim/gz-sim#2726.

## Summary

The major version is removed from the cmake project name for gz-launch in gazebosim/gz-sim#2726, so update the `find_package` call accordingly.

## Test it

* Build gazebosim/gz-sim#2726 and https://github.com/gazebosim/gz-launch/pull/292 from source
* Compile this branch against them
* Confirm this builds successfully

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
